### PR TITLE
refactor: Reorder @layer directives in index.css for better organization

### DIFF
--- a/public/themes/demo/styles/index.css
+++ b/public/themes/demo/styles/index.css
@@ -1,8 +1,4 @@
-@view-transition {
-  navigation: auto;
-}
-
-@layer fonts, colours, vars-typography, vars-layout, vars, reset, media, typography, animations, transitions, global;
+@layer transitions, fonts, colours, vars-typography, vars-layout, vars, reset, media, typography, animations, global;
 
 @import url(./fonts.css) layer(fonts);
 @import url(./colours.css) layer(colours);


### PR DESCRIPTION
This commit reorders the @layer directives in the index.css file to improve the organization of the stylesheets. The transitions layer is moved to the beginning, followed by fonts, colours, vars-typography, vars-layout, vars, reset, media, typography, animations, and global. This change ensures a more logical and consistent order of the styles, making it easier to maintain and understand the codebase.